### PR TITLE
Update rtc_util.c

### DIFF
--- a/STM32F1/libraries/RTClock/src/utility/rtc_util.c
+++ b/STM32F1/libraries/RTClock/src/utility/rtc_util.c
@@ -182,8 +182,10 @@ void rtc_set_count(uint32 value) {
 	rtc_wait_sync();
 	rtc_wait_finished();
 	rtc_enter_config_mode();
-	RTC->regs->CNTH = (value >> 16) & 0xffff;
-	RTC->regs->CNTL = value & 0xffff;
+	do {
+		h = RTC->regs->CNTH & 0xffff;
+		l = RTC->regs->CNTL & 0xffff;
+	} while (h ^ (RTC->regs->CNTH & 0xffff));
 	rtc_exit_config_mode();
 	rtc_wait_finished();
 }
@@ -211,8 +213,10 @@ uint32 rtc_get_divider() {
 	rtc_clear_sync();
 	rtc_wait_sync();
 	rtc_wait_finished();
-	h = RTC->regs->DIVH & 0x000f;
-	l = RTC->regs->DIVL & 0xffff;
+	do {
+		h = RTC->regs->DIVH & 0x000f;
+		l = RTC->regs->DIVL & 0xffff;
+	} while (h ^ (RTC->regs->DIVH & 0x000f));
 	return (h << 16) | l;
 }
 


### PR DESCRIPTION
Modify rtc_get_count() and rtc_get_divider() to fix non-atomic accesses to RTC counter registers. Both now do a double read of the upper word to avoid possible errors when the lower word rollover occurs.